### PR TITLE
added toString method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,13 @@
 'use strict';
-module.exports = function () {
-	return /\bv?(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?\b/ig;
-};
+
+var semverString = "\\bv?(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)(?:-[\\da-z\\-]+(?:\\.[\\da-z\\-]+)*)?(?:\\+[\\da-z\\-]+(?:\\.[\\da-z\\-]+)*)?\\b";
+
+var regex = function(){
+    return new RegExp(semverString, "ig");
+}
+
+regex.toString = function (){
+    return semverString;
+}
+
+module.exports = regex


### PR DESCRIPTION
This patch overrides the `toString()` method which returns the raw regex.
### Use Case

Suppose one has several files in my project with the following header

```
/**
 * @version 0.5.x
 */
```

I can write a task/script to bump the `@version` tag in header of all files using `toString()` method

``` js
var semverRegex = require('semver-regex');
var vesionRegex =  new RegExp("(\s?\*\s+?@version\s+?)(" + semverRegex.toString() + ")");

something.replace(versionRegex, "$1 0.6.0");
```

This patch is 100% backward compatible. All the tests pass.
